### PR TITLE
cli-prompt -> prompt and cmd.exe support in spawn calls

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -13,9 +13,12 @@
     var config = require('../config.js');
     var language = require('../lang.js');
     var chalk = require('chalk');
-    var prompt = require('cli-prompt');
+    var prompt = require('prompt');
     var spawn = require('child_process').spawn;
     var appRoot = require('app-root-path');
+
+    var isWindows = process.platform === 'win32';
+
     //that's so dutty of you
     var conf_file = appRoot.path.split('bin').join('') + "/config.js";
 
@@ -106,8 +109,9 @@
         console.log(chalk.magenta.bold('h) ') + chalk.yellow.bold("Print history"));
       }
 
-      prompt(chalk.green.bold(torrent_site_num), function (val) {
-        torrentSite(val);
+      prompt.message = chalk.green.bold(torrent_site_num);
+      prompt.get('site', function (err, val) {
+        torrentSite(val.site);
       });
     }
 
@@ -117,20 +121,21 @@
         printHistory();
         firstPrompt();
       } else {
-        prompt(chalk.green.bold(search_torrent), function (val) {
+        prompt.message = chalk.green.bold(search_torrent);
+        prompt.get('torrent', function (err, val) {
 
-          if(val){
+          if(val.torrent){
 
             if(site === "k"){
-              kickassSearch(val);
+              kickassSearch(val.torrent);
             } else if (site === "l"){
-              limetorrentSearch(val);
+              limetorrentSearch(val.torrent);
             } else if(site === "e"){
-              extratorrentSearch(val);
+              extratorrentSearch(val.torrent);
             } else if(site === "n"){
-              nyaaSearch(val);
+              nyaaSearch(val.torrent);
             } else if(site === "t"){
-              tokyotoshoSearch(val);
+              tokyotoshoSearch(val.torrent);
             } else {
               console.log("");
               console.log(chalk.white.bgRed.bold(site_error));
@@ -260,9 +265,9 @@
     }
 
     function selectTorrent(data) {
-
-      prompt(chalk.green.bold(select_torrent), function (val) {
-        number = val -1;
+      prompt.message = chalk.green.bold(select_torrent);
+      prompt.get('number', function (err, val) {
+        number = val.number -1;
         console.log('Streaming ' + chalk.green.bold(data[number].title));
         torrent = data[number].torrent_link;
         torrent_title = data[number].title;
@@ -287,9 +292,10 @@
             torrent_count++;
           });
 
-          prompt(chalk.green.bold(select_torrent), function (val) {
+          prompt.message = chalk.green.bold(select_torrent);
+          prompt.get('torrent', function (err, val) {
 
-            torrent_index = val-1;
+            torrent_index = val.torrent-1;
             torrent_title = data[torrent_index];
 
             if(use_subtitle === "true"){
@@ -400,27 +406,37 @@
     }
 
     function streamTorrent_wo_sub_list(torrent, index){
-      spawn(peerflix_command, [torrent, "--i " + index, peerflix_player, peerflix_player_arg, peerflix_port], {
-        stdio: 'inherit'
-      });
+      var argsList = [torrent, "--i " + index, peerflix_player, peerflix_player_arg, peerflix_port];
+      osSpecificSpawn(peerflix_command, argsList);
     }
 
     function streamTorrent_sub_list(torrent, index){
-      spawn(peerflix_command, [torrent, "--subtitles=\"" + peerflix_subtitle + "\"", "--i " + index, peerflix_player, peerflix_player_arg, peerflix_port], {
-        stdio: 'inherit'
-      });
+      var argsList = [torrent, "--subtitles=\"" + peerflix_subtitle + "\"", "--i " + index, peerflix_player, peerflix_player_arg, peerflix_port];
+      osSpecificSpawn(peerflix_command, argsList);
     }
 
     function streamTorrent_wosub(torrent){
-      spawn(peerflix_command, [torrent, peerflix_player, peerflix_player_arg, peerflix_port], {
-        stdio: 'inherit'
-      });
+      var argsList =  [torrent, peerflix_player, peerflix_player_arg, peerflix_port];
+      osSpecificSpawn(peerflix_command, argsList);
     }
 
     function streamTorrent_sub(torrent){
-      spawn(peerflix_command, [torrent, "--subtitles=\"" + peerflix_subtitle + "\"", peerflix_player, peerflix_player_arg, peerflix_port], {
-        stdio: 'inherit'
-      });
+      var argsList = [torrent, "--subtitles=\"" + peerflix_subtitle + "\"", peerflix_player, peerflix_player_arg, peerflix_port];
+      osSpecificSpawn(peerflix_command, argsList);
+    }
+
+    function osSpecificSpawn(command, argsList){
+
+      if(isWindows){
+
+        //we must call peerflix using cmd.exe if on windows
+        argsList.unshift('/c', command);
+        spawn('cmd', argsList);
+      }
+
+      else{
+        spawn(command, argsList, {stdio:'inherit'});
+      }
     }
 
 }).call(this);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chalk": "^0.5.1",
     "cheerio": "^0.18.0",
     "child": "0.0.2",
-    "cli-prompt": "^0.4.1",
+    "prompt": "^0.2.14",
     "commander": "^2.2.0",
     "opensubtitles-client": "^1.3.0",
     "q": "^1.1.2",


### PR DESCRIPTION
I added Windows support to this. 

cli-prompt seems to take enter presses on Windows as a double press, so I swapped to the prompt library which works on all platforms (tested on windows + crunchbang)

Added isWindows check before spawn calls to peerflix as these need to be passed to the cmd.exe binary on Windows.
