### PR TITLE
Refactored main.js, added flag to open in default torrent app

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,6 +19,7 @@
         .version(pkg.version)
         .option('--config', 'Edit torrentflix config EX: torrentflix --config="nano"')
         .option('-s, --search [title]', 'item to search for EX: -s title')
+        .option('-o, --open', 'open torrent with default app or xdg-open')
         //.option('--history', 'View torrentflix history EX: torrentflix --history')
         .option('--clear', 'Clear torrentflix history EX torrentflix --clear')
         //.option('--location', 'Change where torrentflix\' config & history is located EX torrentflix --location"/home/gshock/.config"')
@@ -64,17 +65,21 @@
                     console.log(chalk.red('Run "npm install -g torrentflix'));
                     console.log(chalk.red('Or go here to get it: https://github.com/ItzBlitz98/torrentflix'));
                 }
-                AppInitialize();
+                AppInitialize(program);
 
             } else {
-              AppInitialize();
+              AppInitialize(program);
             }
           });
     }
 
     program.parse(process.argv);
 
-    function AppInitialize() {
+    function AppInitialize(prog) {
+        var appOpts = {
+            open: prog.open,
+            search: prog.search
+        };
         var conf = new Configstore("torrentflix_config", {});
         var hist = new Configstore("torrentflix_history", {});
         if (conf.size < 1) {
@@ -103,9 +108,9 @@
             console.log(chalk.green("A new config file has been created you can find it at: "));
             console.log(chalk.green(conf.path));
 
-            main.AppInitialize(program.search);
+            main.AppInitialize(appOpts);
         } else {
-          main.AppInitialize(program.search);
+          main.AppInitialize(appOpts);
         }
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -24,9 +24,10 @@
     var inquirer = require('inquirer');
     var spawn = require('child_process').spawn;
     var path = require('path');
+    var opn = require('opn');
     var appDir = path.dirname(require.main.filename).split('bin').join('');
     var isWindows = process.platform === 'win32';
-    var searchValue = undefined;
+    var options = {};
     var kickass_url, rarbg_url, btdigg_url, limetorrents_url, extratorrent_url, yts_url,
         tpb_url, nyaa_url, tokyotosho_url, peerflix_player, peerflix_player_arg,
         peerflix_port, peerflix_command, use_subtitle, subtitle_language, history, history_location,
@@ -45,8 +46,8 @@
     var get_conf_object = new Configstore("torrentflix_config", {});
     var get_hist_object = new Configstore("torrentflix_history", {});
 
-    exports.AppInitialize = start = function(searchFor) {
-        searchValue = searchFor;
+    exports.AppInitialize = start = function(optns) {
+      options = optns;
       config_object = get_conf_object.all;
 
       //setting up vars from config
@@ -142,11 +143,10 @@
       } else if(site == "exit"){
         exitApp();
       } else {
-
-        if (searchValue) {
-            passoffSearch(searchValue);
+        if(options.search) {
+            passoffSearch(options.search);
         } else {
-            inquirer.prompt([
+          inquirer.prompt([
               {
                 type: "input",
                 name: "search",
@@ -157,6 +157,7 @@
           });
         }
         function passoffSearch( search ) {
+          console.log(chalk.green("Searching for ") + chalk.blue(search));
           if(site === "kickass"){
             kickassSearch(search);
           } else if(site === "rarbg"){
@@ -189,485 +190,165 @@
     }
 
     function btdiggSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      btdigg.search(query, btdigg_url).then(function onResolve(data) {
-        for (var torrent in data) {
-          var number = data[torrent].torrent_num;
-          var title = data[torrent].title;
-          var size = data[torrent].size;
-
-          if(history == "true"){
-            var found = searchHistory(title);
-            if(found){
-               title_size = chalk.red(data[torrent].title);
-             } else {
-               title_size = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title_size = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title_size + (' ') + chalk.blue(size) + (' ')
-          );
-        }
-
-        selectTorrent(data);
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      btdigg.search(query, btdigg_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
     function leetxSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-
-      leetx.search(query, leetx_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
-
+      leetx.search(query, leetx_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
+
 
 
     function seedpeerSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-
-      seedpeer.search(query, seedpeer_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan(" " + data[torrent].date_added + "");
-          } else {
-            date_added = "";
-          }
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + date_added + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
-
+      seedpeer.search(query, seedpeer_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
     function rarbgSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      rarbg.search(query, cat, page, rarbg_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan(" " + data[torrent].date_added + "");
-          } else {
-            date_added = "";
-          }
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + date_added + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      rarbg.search(query, cat, page, rarbg_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
     function extratorrentSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query) + chalk.red(" (*note Extratorrent does not sort by seeds)"));
-      extratorrent.search(query, cat, page, extratorrent_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      console.log(chalk.red("(*note Extratorrent does not sort by seeds)"));
+      extratorrent.search(query, cat, page, extratorrent_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
     function strikeSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      strike.search(query, cat, page, strike_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan(" " + data[torrent].date_added + "");
-          } else {
-            date_added = "";
-          }
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + date_added + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      strike.search(query, cat, page, strike_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
 
     function ytsSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      yts.search(query, cat, page, yts_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leech;
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan(" " + data[torrent].date_added + "");
-          } else {
-            date_added = "";
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + date_added + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      yts.search(query, cat, page, yts_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
 
     function tpbSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
       console.log(chalk.red("Use caution using thepiratebay, Fake torrents are common, Look for trusted uploader skull."));
-      tpb.search(query, cat, page, tpb_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var torrent_verified, date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(data[torrent].torrent_verified == "vip"){
-            torrent_verified = chalk.green(" 💀  ");
-          } else if(data[torrent].torrent_verified == "trusted"){
-            torrent_verified = chalk.magenta(" 💀  ");
-          } else {
-            torrent_verified = " ";
-          }
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan("" + data[torrent].date_added + " ");
-          } else {
-            date_added = "";
-          }
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + torrent_verified + date_added + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      tpb.search(query, cat, page, tpb_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
     function limetorrentSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      limetorrents.search(query, cat, page, limetorrents_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan(" " + data[torrent].date_added + "");
-          } else {
-            date_added = "";
-          }
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + date_added + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      limetorrents.search(query, cat, page, limetorrents_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
     function kickassSearch(query) {
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      kickass.search(query, cat, page, kickass_url).then(function onResolve(data) {
-        for (var torrent in data) {
-          var date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-          var torrent_verified = data[torrent].torrent_verified;
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan("" + data[torrent].date_added + " ");
-          } else {
-            date_added = "";
-          }
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + chalk.green(torrent_verified) + date_added + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data, query);
-
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      kickass.search(query, cat, page, kickass_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
 
     function nyaaSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      nyaa.search(query, cat, page, nyaa_url).then(function onResolve(data) {
-
-        for (var torrent in data) {
-          var title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
-
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
-        }
-
-        selectTorrent(data);
-
-      }, function onReject(err) {
-        console.log(chalk.red(err));
-        firstPrompt();
-      });
+      nyaa.search(query, cat, page, nyaa_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
     }
 
     function tokyotoshoSearch(query){
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
-      tokyotosho.search(query, cat, page, tokyotosho_url).then(function onResolve(data) {
-        for (var torrent in data) {
-          var date_added, title;
-          var number = data[torrent].torrent_num;
-          //var title = data[torrent].title;
-          var size = data[torrent].size;
-          var seed = data[torrent].seeds;
-          var leech = data[torrent].leechs;
-          if(conf_date_added == "true"){
-            date_added = chalk.cyan(" " + data[torrent].date_added + "");
-          } else {
-            date_added = "";
-          }
+      tokyotosho.search(query, cat, page, tokyotosho_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
+    }
 
-          if(history == "true"){
-            var found = searchHistory(data[torrent].title);
-            if(found){
-               title = chalk.red(data[torrent].title);
-             } else {
-               title = chalk.yellow(data[torrent].title);
-             }
-          } else {
-            title = chalk.yellow(data[torrent].title);
-          }
+    function onResolve(data) {
+        for (var idx in data) {
+            var torrent = data[idx];
+            var date_added, title;
+            var number = torrent.torrent_num;
+            var size = torrent.size;
+            var seed = torrent.seeds;
+            var leech = torrent.leechs;
+            var torrent_verified = " ";
 
-          console.log(
-            chalk.magenta(number) + chalk.magenta('\) ') + title + date_added + (' ') + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
-          );
+            if(torrent.torrent_verified) {
+                torrent_verified = torrent.torrent_verified;
+                if(torrent.torrent_verified == "vip"){
+                  torrent_verified = chalk.green(" 💀  ");
+                } else if(torrent.torrent_verified == "trusted"){
+                  torrent_verified = chalk.magenta(" 💀  ");
+                }
+            }
+
+            if(conf_date_added == "true"){
+              date_added = chalk.cyan("" + torrent.date_added + " ");
+            } else {
+              date_added = "";
+            }
+
+            if(history == "true"){
+              var found = searchHistory(torrent.title);
+              if(found){
+                 title = chalk.red(torrent.title);
+               } else {
+                 title = chalk.yellow(torrent.title);
+               }
+            } else {
+              title = chalk.yellow(torrent.title);
+            }
+            console.log(
+              chalk.magenta(number) + chalk.magenta('\) ') + title + chalk.green(torrent_verified) + date_added + chalk.blue(size) + (' ') + chalk.green(seed) + (' ') + chalk.red(leech)
+            );
         }
-
         selectTorrent(data);
-      }, function onReject(err) {
+    }
+
+    function onReject(err) {
         console.log(chalk.red(err));
         firstPrompt();
-      });
     }
 
     function selectTorrent(data) {
@@ -703,20 +384,26 @@
 
           //do some checking to see if we got a magnet link or a link to the torrent page
           //not all torrent sites have the link on the index
-          if(data[number].torrent_link){
-
-            console.log('Streaming ' + chalk.green(torrent_title));
+          if(data[number].torrent_link) {
             torrent = data[number].torrent_link;
-            parseTorrent(torrent, torrent_title);
+            if(options.open) {
+                console.log('Opening ' + chalk.green(torrent_title));
+                opn(torrent);
+            } else {
+                console.log('Streaming ' + chalk.green(torrent_title));
+                parseTorrent(torrent, torrent_title);
+            }
 
-          } else if(data[number].torrent_site){
-
+          } else if(data[number].torrent_site) {
             torrent_search.torrentSearch(data[number].torrent_site).then(function(data) {
-
-              console.log('Streaming ' + chalk.green(torrent_title));
               torrent = data;
-              parseTorrent(torrent, torrent_title);
-
+              if(options.open) {
+                  console.log('Opening ' + chalk.green(torrent_title));
+                  opn(torrent);
+              } else {
+                  console.log('Streaming ' + chalk.green(torrent_title));
+                  parseTorrent(torrent, torrent_title);
+              }
 
             }, function onReject(err) {
               console.log(chalk.red(err));

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "inquirer": "^0.8.0",
     "moment": "^2.9.0",
     "opensubtitles-client": "^1.3.0",
+    "opn": "^3.0.2",
     "q": "^2.0.3",
     "read-torrent": "^1.2.0",
     "request": "^2.51.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": {
     "name": "ItzBlitz98"
   },
+  "contributors" : {
+    "name": "Evan Cameron <www.github.com/leshow>"  
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ItzBlitz98/torrentflix.git"


### PR DESCRIPTION
I hope you like the changes, I simplified main.js significantly.

Changes:
- added an **--open** flag (-o --open , etc all work via commander) when in place the behaviour changes from streaming with vlc to opening with the **default torrent client** (xdg-open on linux, for me it opens with transmission). This means we can use your project to search for **any** kind of torrent, not just video content!
- refactored options passing to main.js
- refactored torrent search callbacks to remove copy pasta

Please review these changes and let me know what you think, I hope you don't mind that I added myself to a "contributors" tag in package.json. I can revert that change if you don't want it.

Let me know what you think!
