### PR TITLE
Adding cpasbien support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A cli tool for searching torrent sites and streaming using peerflix.
 
-It currently supports kickasstorrents, 1337x, seedpeer, Rarbg, The Pirate Bay, YTS, Extratorrent, Limetorrents, nyaa.se & tokyotosho.
+It currently supports kickasstorrents, 1337x, seedpeer, Rarbg, The Pirate Bay, YTS, Extratorrent, Limetorrents, nyaa.se, tokyotosho & Cpasbien.
 
 Want more ? Create an issue with a request, Alternatively you can contribute your own scrapers.
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -96,6 +96,7 @@
             conf.set("leetx_url", "https://1337x.to");
             conf.set("nyaa_url", "http://www.nyaa.se");
             conf.set("tokyotosho_url", "https://www.tokyotosho.info");
+            conf.set("cpasbien_url", "http://www.cpasbien.pw");
             conf.set("peerflix_player", "--vlc");
             conf.set("peerflix_player_args", "");
             conf.set("peerflix_port", "--port=8888");

--- a/lib/cpasbien.js
+++ b/lib/cpasbien.js
@@ -1,0 +1,64 @@
+var Q = require('q');
+var request = require("request");
+var cheerio = require('cheerio');
+var moment = require('moment');
+
+module.exports = {
+  search: function(query, cpasbien_url) {
+
+    var torrent_search = query;
+    var search_query = torrent_search.split(' ').join('-');
+    var search_url = cpasbien_url + "/recherche/" + search_query + ".html";
+    var count = 1;
+    var deferred = Q.defer();
+    var data_content = {};
+    var torrent_content = [];
+
+    request(search_url, function(err, response, body){
+    
+      if(!err && response.statusCode === 200){
+
+        var cpasbien_link, torrent_title, torrent_size, torrent_seeds, torrent_leech, date_added;
+        $ = cheerio.load(body);
+
+        if($("div .ligne0").length > 0) {
+
+          $("div[class^='ligne']").each(function(index, torrent){
+            cpasbien_link = $(torrent).children("a").attr('href');
+            torrent_title = $(torrent).children("a").text();
+            torrent_size = $(torrent).children(".poid").text();
+            torrent_seeds = $(torrent).find(".seed_ok").text();
+            torrent_leech = $(torrent).find(".down").text();
+            date_added = undefined;
+
+            data_content = {
+              torrent_num: count,
+              title: torrent_title,
+              category: "",
+              seeds: torrent_seeds,
+              leechs: torrent_leech,
+              size: torrent_size,
+              torrent_site: cpasbien_link,
+              date_added: date_added
+            };
+
+            torrent_content.push(data_content);
+
+            deferred.resolve(torrent_content);
+            count++;
+          });
+
+        } else {
+          deferred.reject("No torrents found");
+        }
+
+      } else {
+        deferred.reject("There was a problem loading Cpasbien");
+      }
+
+    });
+
+    return deferred.promise;
+
+  }
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -18,6 +18,7 @@
     var leetx = require('./1337x.js');
     var nyaa = require('./nyaa.js');
     var tokyotosho = require('./tokyotosho.js');
+    var cpasbien = require('./cpasbien.js');
     var tparse = require('./torrent_parse.js');
     var language = require('../lang.js');
     var chalk = require('chalk');
@@ -62,6 +63,7 @@
       nyaa_url = config_object.nyaa_url;
       btdigg_url = config_object.btdigg_url;
       tokyotosho_url = config_object.tokyotosho_url;
+      cpasbien_url = config_object.cpasbien_url;
       strike_url = config_object.strike_url;
       peerflix_player = config_object.peerflix_player;
       peerflix_player_arg = config_object.peerflix_player_args;
@@ -116,6 +118,9 @@
       }
       if(tokyotosho_url){
         sites.push({'key': "tokyotosho", name: chalk.magenta('Tokyotosho'), value: "tokyotosho"});
+      }
+      if(cpasbien_url){
+        sites.push({'key': "cpasbien", name: chalk.magenta('Cpasbien'), value: "cpasbien"});
       }
       if(history === "true"){
         sites.push({'key': "print history", name: chalk.blue('Print history'), value: "print history"});
@@ -182,6 +187,8 @@
             nyaaSearch(search);
           } else if(site === "tokyotosho"){
             tokyotoshoSearch(search);
+          } else if(site === "cpasbien"){
+            cpasbienSearch(search);
           }
         }
 
@@ -297,6 +304,15 @@
 
     function tokyotoshoSearch(query){
       tokyotosho.search(query, cat, page, tokyotosho_url).then(
+        function (data) {
+            onResolve(data);
+        }, function (err) {
+            onReject(err);
+        });
+    }
+
+    function cpasbienSearch(query){
+      cpasbien.search(query, cpasbien_url).then(
         function (data) {
             onResolve(data);
         }, function (err) {

--- a/lib/torrent_search.js
+++ b/lib/torrent_search.js
@@ -1,6 +1,7 @@
 var request = require("request");
 var cheerio = require('cheerio');
 var Q = require('q');
+var url = require("url");
 
 module.exports = {
   torrentSearch: function(torrent_site) {
@@ -16,7 +17,6 @@ module.exports = {
     };
     
     theJar.setCookie('7fAY799j=VtdTzG69', torrent_site, {"ignoreError":true});
-
     request(options, function(err, response, body){
 
       if(!err && response.statusCode === 200){
@@ -25,14 +25,23 @@ module.exports = {
 
         links = $(body).find('a');
 
+        var magnet_link, torrent_link;
         $(links).each(function(i, link){
           if($(link).attr('href')){
             if($(link).attr('href').indexOf("magnet:?xt=urn:btih:") > -1) {
               magnet_link = $(link).attr('href');
               deferred.resolve(magnet_link);
             }
+            else if($(link).attr('href').indexOf(".torrent") > -1) {
+              torrent_link = $(link).attr('href');
+              deferred.resolve(url.resolve(torrent_site, torrent_link));
+            }
           }
         });
+
+      if(!magnet_link && !torrent_link) {
+        deferred.reject("No torrent found on the page");
+      }
 
 
       } else {


### PR DESCRIPTION
A pull request for cpasbien support (French torrent site).
Main code changes:
1- create the scraper file cpasbien.js
2- add the scraper to the cli.js, main.js
3- update torrent_search.js to a) find .torrent links, not just magnets (cpasbien publishes torrent files instead of magnets) and b) report an error if no magnet or torrent_link can be found
Maybe you will want to tackle 3- differently 
