### PR TITLE
Change trackers order

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -84,8 +84,14 @@
 
     function firstPrompt(){
       var sites = [];
+      if(yts_url){
+        sites.push({'key': "yts", name: chalk.magenta('YTS'), value: "yts"});
+      }
       if(kickass_url){
         sites.push({'key': "kickass", name: chalk.magenta('Kickass'), value: "kickass"});
+      }
+      if(tpb_url){
+        sites.push({'key': "tpb", name: chalk.magenta('The Pirate Bay'), value: "tpb"});
       }
       if(rarbg_url){
         sites.push({'key': "rarbg", name: chalk.magenta('Rarbg'), value: "rarbg"});
@@ -101,12 +107,6 @@
       }
       if(leetx_url){
         sites.push({'key': "leetx", name: chalk.magenta('1337x'), value: "leetx"});
-      }
-      if(yts_url){
-        sites.push({'key': "yts", name: chalk.magenta('YTS'), value: "yts"});
-      }
-      if(tpb_url){
-        sites.push({'key': "tpb", name: chalk.magenta('The Pirate Bay'), value: "tpb"});
       }
       if(limetorrents_url){
         sites.push({'key': "limetorrents", name: chalk.magenta('LimeTorrents'), value: "limetorrents"});


### PR DESCRIPTION
This PR might be a little subjective, but it's how I use torrentflix and wanted to see what you think.
When I watch movies from streaming, YTS is definitely the best option (and most popular), then KAT for the rest of the films/tv shows, and ultimately I search on TPB mainly because its popularity. I didn't know about rarbg and seedpeer or BTDigg for example, and I've no idea why they would appear first in the list.

Have you ever considered on changing this? It gets a bit tedious, at least for me, to scroll down to the tracker I want every time I search for a file.

As an alternative, I suggest we use a config array where the user can easily modify this.
