### PR TITLE
One search for all sources

### DIFF
--- a/lib/btdigg.js
+++ b/lib/btdigg.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, btdigg_url) {
+  search: function(query, btdigg_url, cat, page) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('%20');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,10 @@
     var config_object, settings_object, history_object;
     var blank_history = [];
 
+    // definition of all options
+    // example for source scrapers - short_name: {name: longname, url: base_url}
+    // short name has to be equal to the name of the scraper object define in 
+    // main.js 
     var config_vars = {
         "torrent_sources": {
             "kickass": {
@@ -84,7 +88,7 @@
             "history":              "false",
             "date_added":           "false",
         }          
-    }
+    };
 
     //setting up command line options
     program
@@ -155,8 +159,6 @@
         var hist = new Configstore("torrentflix_history", {});
         if (conf.size < 1) {
             //create config file with default
-            
-            //add sources and options in the config file
             conf.set(config_vars);
 
             console.log(chalk.green("A new config file has been created you can find it at: "));
@@ -165,13 +167,13 @@
             main.AppInitialize(appOpts);
         } else {
 
-            //config file exist, get values
+            // config file exist, get values
             var conf_file = conf.all;
             var need_save = false;
-            //and create these if not exists
-            for (type in config_vars) {
-                for (option in config_vars[type]) {
-                    if (!(option in conf_file[type])){
+            // create these if not exists
+            for (var type in config_vars) {
+                for (var option in config_vars[type]) {
+                    if (!(option in conf_file[type])) {
                         conf_file[type][option] = config_vars[type][option];
                         need_save = true;
                     } 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,33 +14,76 @@
     var config_object, settings_object, history_object;
     var blank_history = [];
 
-    var torrent_sources = {
-        "kickass_url":      "https://kat.cr",
-        "limetorrents_url": "http://limetorrents.cc",
-        "extratorrent_url": "http://extratorrent.cc",
-        "strike_url":       "https://getstrike.net",
-        "yts_url":          "https://yts.ag",
-        "tpb_url":          "https://thepiratebay.la",
-        "btdigg_url":       "https://btdigg.org",
-        "seedpeer_url":     "http://seedpeer.eu",
-        "leetx_url":        "https://1337x.to",
-        "nyaa_url":         "http://www.nyaa.se",
-        "tokyotosho_url":   "https://www.tokyotosho.info",
-        "cpasbien_url":     "http://www.cpasbien.io",
-        "eztv_url":         "https://www.eztv.ag",
-        "rarbg_api_url":    "https://torrentapi.org"
-    }
-
-    var conf_options = {
-        "peerflix_player":      "--vlc",
-        "peerflix_player_args": "",
-        "peerflix_port":        "--port=8888",
-        "peerflix_path":        "",
-        "peerflix_command":     "peerflix",
-        "use_subtitle":         "false",
-        "subtitle_language":    "eng",
-        "history":              "false",
-        "date_added":           "false"
+    var config_vars = {
+        "torrent_sources": {
+            "kickass": {
+                name: 'Kickass',
+                url: "https://kat.cr"
+            },
+            "limetorrents": {
+                name: 'LimeTorrents',
+                url: "http://limetorrents.cc"
+            },
+            "extratorrent": {
+                name: 'ExtraTorrent',
+                url: "http://extratorrent.cc"
+            },
+            "strike": {
+                name: 'GetStrike',
+                url: "https://getstrike.net"
+            },
+            "yts": {
+                name: 'YTS',
+                url: "https://yts.ag"
+            },
+            "tpb": {
+                name: 'The Pirate Bay',
+                url: "https://thepiratebay.la"
+            },
+            "btdigg": {
+                name: 'BTDigg',
+                url: "https://btdigg.org"
+            },
+            "seedpeer": {
+                name: 'Seedpeer',
+                url: "http://seedpeer.eu"
+            },
+            "leetx": {
+                name: '1337x',
+                url: "https://1337x.to"
+            },
+            "nyaa": {
+                name: 'Nyaa',
+                url: "http://www.nyaa.se"
+            },
+            "tokyotosho": {
+                name: 'Tokiotosho',
+                url: "https://www.tokyotosho.info"
+            },
+            "cpasbien": {
+                name: 'Cpasbien',
+                url: "http://www.cpasbien.io"
+            },
+            "eztv": {
+                name: 'Eztv',
+                url: "https://www.eztv.ag"
+            },
+            "rarbg": {
+                name: 'Rarbg',
+                url: "https://torrentapi.org"
+            }
+        },
+        "options": {
+            "peerflix_player":      "--vlc",
+            "peerflix_player_args": "",
+            "peerflix_port":        "--port=8888",
+            "peerflix_path":        "",
+            "peerflix_command":     "peerflix",
+            "use_subtitle":         "false",
+            "subtitle_language":    "eng",
+            "history":              "false",
+            "date_added":           "false",
+        }          
     }
 
     //setting up command line options
@@ -96,12 +139,9 @@
                     console.log("");
                     console.log(chalk.red('Or go here to get it: https://github.com/ItzBlitz98/torrentflix'));
                 }
-                AppInitialize(program);
-
-            } else {
-              AppInitialize(program);
             }
-          });
+            AppInitialize(program);
+        });
     }
 
     program.parse(process.argv);
@@ -116,14 +156,8 @@
         if (conf.size < 1) {
             //create config file with default
             
-            //add sources in the config file
-            for (var source in torrent_sources) {
-                conf.set(source, torrent_sources[source]);
-            }
-            //add config options
-            for (var option in conf_options) {
-                conf.set(option, conf_options[option]);
-            }
+            //add sources and options in the config file
+            conf.set(config_vars);
 
             console.log(chalk.green("A new config file has been created you can find it at: "));
             console.log(chalk.green(conf.path));
@@ -131,20 +165,24 @@
             main.AppInitialize(appOpts);
         } else {
 
-            //config file exist, make verifications
+            //config file exist, get values
+            var conf_file = conf.all;
+            var need_save = false;
+            //and create these if not exists
+            for (type in config_vars) {
+                for (option in config_vars[type]) {
+                    if (!(option in conf_file[type])){
+                        conf_file[type][option] = config_vars[type][option];
+                        need_save = true;
+                    } 
+                }
+            }
 
-            //create source if not exist
-            for (var source in torrent_sources) {
-                if(!conf.get(source)){
-                    conf.set(source, torrent_sources[source]);
-                }
+            //save updates
+            if (need_save) { 
+                conf.set(conf_file);
             }
-            //create options if not exist
-            for (var option in conf_options) {
-                if(!conf.get(option)){
-                    conf.set(option, conf_options[option]);
-                }
-            }
+
 
           main.AppInitialize(appOpts);
         }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -91,7 +91,7 @@
         .version(pkg.version)
         .option('--config', 'Edit torrentflix config EX: torrentflix --config="nano"')
         .option('-s, --search [title]', 'item to search for EX: -s title')
-        .option('-o, --open', 'open torrent with default app or xdg-open')
+        .option('-o, --open [title]', 'open torrent with default app or xdg-open')
         //.option('--history', 'View torrentflix history EX: torrentflix --history')
         .option('--clear', 'Clear torrentflix history EX torrentflix --clear')
         //.option('--location', 'Change where torrentflix\' config & history is located EX torrentflix --location"/home/gshock/.config"')

--- a/lib/cpasbien.js
+++ b/lib/cpasbien.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, cpasbien_url) {
+  search: function(query, cpasbien_url, cat, page) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('-');

--- a/lib/extratorrent.js
+++ b/lib/extratorrent.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, cat, page, extratorrent_url) {
+  search: function(query, extratorrent_url, cat, page) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');

--- a/lib/eztv.js
+++ b/lib/eztv.js
@@ -6,7 +6,7 @@ var util = require('util');
 var fs = require('fs');
 
 module.exports = {
-  search: function(query, eztv_url) {
+  search: function(query, eztv_url, cat, page) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('-');

--- a/lib/kickass.js
+++ b/lib/kickass.js
@@ -3,15 +3,13 @@ var request = require("request");
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, cat, page, kickass_url) {
+  search: function(query, kickass_url, cat, page) {
     var count = 1;
     var deferred = Q.defer();
     var data_content = {};
     var torrent_content = [];
     var torrent_verified;
-
     var search_url = kickass_url + '/json.php?q=' + encodeURIComponent(query) + '&field=seeders&order=desc&page=' + page;
-
     request(search_url, function(err, response, body){
 
       if(!err && response.statusCode === 200){

--- a/lib/limetorrents.js
+++ b/lib/limetorrents.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, cat, page, limetorrents_url) {
+  search: function(query, limetorrents_url, cat, page) {
 
     if(!cat){
       cat = "all";

--- a/lib/main.js
+++ b/lib/main.js
@@ -129,7 +129,7 @@
       } else {
         if (options.search) {
             passoffSearch(options.search);
-        } else if(options.open) {
+        } else if(options.open && options.open != true) {
             passoffSearch(options.open);
         } else {
           inquirer.prompt([

--- a/lib/main.js
+++ b/lib/main.js
@@ -129,6 +129,8 @@
       } else {
         if (options.search) {
             passoffSearch(options.search);
+        } else if(options.open) {
+            passoffSearch(options.open);
         } else {
           inquirer.prompt([
             {

--- a/lib/main.js
+++ b/lib/main.js
@@ -63,25 +63,24 @@
       'nyaa': nyaa,
       'tokyotosho': tokyotosho,
       'eztv': eztv
-    }
-
+    };
 
     exports.AppInitialize = start = function(optns) {
       options = optns;
       config_object = get_conf_object.all;
 
       //setting up vars from config
-      peerflix_player = config_object["options"]["peerflix_player"];
+      peerflix_player = config_object.options.peerflix_player;
       console.log(peerflix_player);
-      peerflix_player_arg = config_object["options"]["peerflix_player_args"];
-      peerflix_port = config_object["options"]["peerflix_port"];
-      peerflix_command = config_object["options"]["peerflix_command"];
-      use_subtitle = config_object["options"]["use_subtitle"];
-      subtitle_language = config_object["options"]["subtitle_language"];
-      history = config_object["options"]["history"];
-      conf_date_added = config_object["options"]["date_added"];
+      peerflix_player_arg = config_object.options.peerflix_player_args;
+      peerflix_port = config_object.options.peerflix_port;
+      peerflix_command = config_object.options.peerflix_command;
+      use_subtitle = config_object.options.use_subtitle;
+      subtitle_language = config_object.options.subtitle_language;
+      history = config_object.options.history;
+      conf_date_added = config_object.options.date_added;
       page = 1;
-      peerflix_path = config_object["options"]["peerflix_path"];
+      peerflix_path = config_object.options.peerflix_path;
 
       firstPrompt();
 
@@ -89,19 +88,19 @@
 
 
 
-    function firstPrompt(){
+    function firstPrompt() {
       var sites = [];
 
-      for (source in config_object["torrent_sources"]){
+      for (var source in config_object.torrent_sources) {
         // add torrent sources 
         sites.push({
             'key': source,
-            name: chalk.magenta(config_object["torrent_sources"][source].name),
+            name: chalk.magenta(config_object.torrent_sources[source].name),
             value: source
           });
       }
       
-      if(history === "true"){
+      if (history === "true") {
         sites.push({
           'key': "print history",
           name: chalk.blue('Print history'),
@@ -111,79 +110,46 @@
 
       sites.push({'key': "exit", name: chalk.red('Exit app'), value: "exit"});
 
-      inquirer.prompt([
-        {
+      inquirer.prompt([{
           type: "list",
           name: "site",
           message: chalk.green("What torrent site do you want to search?"),
           choices: sites
-        }
-        ], function( answer ) {
+        }], function( answer ) {
           torrentSite(answer.site);
-        });
+        }); 
     }
+    function torrentSite(site) {
 
-    function torrentSite(site){
-
-      if(site == "print history"){
+      if (site == "print history") {
         printHistory();
         firstPrompt();
-      } else if(site == "exit"){
+      } else if (site == "exit") {
         exitApp();
       } else {
-        if(options.search) {
+        if (options.search) {
             passoffSearch(options.search);
         } else {
           inquirer.prompt([
-              {
-                type: "input",
-                name: "search",
-                message: chalk.green(search_torrent),
-              }
-          ], function(answer) {
-              passoffSearch(answer.search);
+            {
+              type: "input",
+              name: "search",
+              message: chalk.green(search_torrent),
+            }
+          ], 
+          function(answer) {
+            query = answer.search;
+            console.log(chalk.green("Searching for ") + chalk.blue(query));
+            Search(query, site, cat, page);          
           });
         }
-        function passoffSearch( search ) {
-          console.log(chalk.green("Searching for ") + chalk.blue(search));
-          console.log(site);
-          Search(site, search);
-          // if(site === "kickass"){
-          //   kickassSearch(search);
-          // } else if(site === "rarbg"){
-          //   rarbgSearch(search);
-          // } else if(site === "seedpeer"){
-          //   seedpeerSearch(search);
-          // } else if(site === "strike"){
-          //   strikeSearch(search);
-          // } else if(site === "btdigg"){
-          //   btdiggSearch(search);
-          // } else if(site === "leetx"){
-          //   leetxSearch(search);
-          // } else if(site === "limetorrents"){
-          //   limetorrentSearch(search);
-          // } else if(site === "yts"){
-          //   ytsSearch(search);
-          // } else if(site === "tpb"){
-          //   tpbSearch(search);
-          // } else if(site === "extratorrent"){
-          //   extratorrentSearch(search);
-          // } else if (site === "nyaa"){
-          //   nyaaSearch(search);
-          // } else if(site === "tokyotosho"){
-          //   tokyotoshoSearch(search);
-          // } else if(site === "cpasbien"){
-          //   cpasbienSearch( search);
-          // } else if(site === "eztv"){
-          //   eztvSearch(search);
-          // }
-        }
-
       }
-
     }
-    function Search(site, query){
-      scrapers[site].search(query, config_object['torrent_sources'][site].url).then(
+
+    function Search(query, site, cat, page) {
+      // general search function for all sources
+      search_url = config_object.torrent_sources[site].url;
+      scrapers[site].search(query, search_url, cat, page).then(
         function (data) {
             onResolve(data);
         }, function (err) {
@@ -191,138 +157,6 @@
         });
     }
 
-    // function btdiggSearch(query){
-    //   btdigg.search(query, btdigg_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function leetxSearch(query){
-    //   leetx.search(query, leetx_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-
-
-    // function seedpeerSearch(query){
-    //   seedpeer.search(query, seedpeer_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function rarbgSearch(query){
-    //   rarbg.search(query, cat, page, rarbg_api_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function extratorrentSearch(query){
-    //   console.log(chalk.red("(*note Extratorrent does not sort by seeds)"));
-    //   extratorrent.search(query, cat, page, extratorrent_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function strikeSearch(query){
-    //   strike.search(query, cat, page, strike_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-
-    // function ytsSearch(query){
-    //   yts.search(query, cat, page, yts_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-
-    // function tpbSearch(query){
-    //   //console.log(chalk.red("Use caution using thepiratebay, Fake torrents are common, Look for trusted uploader skull."));
-    //   tpb.search(query, cat, page, tpb_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function limetorrentSearch(query){
-    //   limetorrents.search(query, cat, page, limetorrents_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function kickassSearch(query) {
-    //   kickass.search(query, cat, page, kickass_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-
-    // function nyaaSearch(query){
-    //   nyaa.search(query, cat, page, nyaa_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function tokyotoshoSearch(query){
-    //   tokyotosho.search(query, cat, page, tokyotosho_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function cpasbienSearch(query){
-    //   cpasbien.search(query, cpasbien_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
-
-    // function eztvSearch(query){
-    //   eztv.search(query, eztv_url).then(
-    //     function (data) {
-    //         onResolve(data);
-    //     }, function (err) {
-    //         onReject(err);
-    //     });
-    // }
 
     function onResolve(data) {
         for (var idx in data) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -30,10 +30,10 @@
     var appDir = path.dirname(require.main.filename).split('bin').join('');
     var isWindows = process.platform === 'win32';
     var options = {};
-    var kickass_url, rarbg_url, btdigg_url, limetorrents_url, extratorrent_url, yts_url,
-        tpb_url, nyaa_url, tokyotosho_url, rarbg_api_url, peerflix_player, peerflix_player_arg,
-        peerflix_port, peerflix_command, use_subtitle, subtitle_language, history, history_location,
-        conf_date_added, history_object, config_location, cat, page, peerflix_path;
+    var peerflix_player, peerflix_player_arg, peerflix_port, peerflix_command, 
+        use_subtitle, subtitle_language, history, history_location,
+        conf_date_added, history_object, config_location, cat, page, 
+        peerflix_path;
 
     //load in language settings
     var lang = language.getEn();
@@ -48,36 +48,40 @@
     var get_conf_object = new Configstore("torrentflix_config", {});
     var get_hist_object = new Configstore("torrentflix_history", {});
 
+    var scrapers = {
+      'cpasbien': cpasbien,
+      'kickass': kickass,
+      'rarbg': rarbg,
+      'strike': strike,
+      'limetorrents': limetorrents,
+      'extratorrent': extratorrent,
+      'tpb': tpb,
+      'yts': yts,
+      'btdigg': btdigg,
+      'seedpeer': seedpeer,
+      'leetx': leetx,
+      'nyaa': nyaa,
+      'tokyotosho': tokyotosho,
+      'eztv': eztv
+    }
+
+
     exports.AppInitialize = start = function(optns) {
       options = optns;
       config_object = get_conf_object.all;
 
       //setting up vars from config
-      kickass_url = config_object.kickass_url;
-      rarbg_url = config_object.rarbg_url;
-      rarbg_api_url = config_object.rarbg_api_url;
-      limetorrents_url = config_object.limetorrents_url;
-      extratorrent_url = config_object.extratorrent_url;
-      yts_url = config_object.yts_url;
-      seedpeer_url = config_object.seedpeer_url;
-      leetx_url = config_object.leetx_url;
-      tpb_url = config_object.tpb_url;
-      nyaa_url = config_object.nyaa_url;
-      btdigg_url = config_object.btdigg_url;
-      tokyotosho_url = config_object.tokyotosho_url;
-      cpasbien_url = config_object.cpasbien_url;
-      eztv_url = config_object.eztv_url;
-      strike_url = config_object.strike_url;
-      peerflix_player = config_object.peerflix_player;
-      peerflix_player_arg = config_object.peerflix_player_args;
-      peerflix_port = config_object.peerflix_port;
-      peerflix_command = config_object.peerflix_command;
-      use_subtitle = config_object.use_subtitle;
-      subtitle_language = config_object.subtitle_language;
-      history = config_object.history;
-      conf_date_added = config_object.date_added;
+      peerflix_player = config_object["options"]["peerflix_player"];
+      console.log(peerflix_player);
+      peerflix_player_arg = config_object["options"]["peerflix_player_args"];
+      peerflix_port = config_object["options"]["peerflix_port"];
+      peerflix_command = config_object["options"]["peerflix_command"];
+      use_subtitle = config_object["options"]["use_subtitle"];
+      subtitle_language = config_object["options"]["subtitle_language"];
+      history = config_object["options"]["history"];
+      conf_date_added = config_object["options"]["date_added"];
       page = 1;
-      peerflix_path = config_object.peerflix_path;
+      peerflix_path = config_object["options"]["peerflix_path"];
 
       firstPrompt();
 
@@ -87,50 +91,22 @@
 
     function firstPrompt(){
       var sites = [];
-      if(yts_url){
-        sites.push({'key': "yts", name: chalk.magenta('YTS'), value: "yts"});
+
+      for (source in config_object["torrent_sources"]){
+        // add torrent sources 
+        sites.push({
+            'key': source,
+            name: chalk.magenta(config_object["torrent_sources"][source].name),
+            value: source
+          });
       }
-      if(kickass_url){
-        sites.push({'key': "kickass", name: chalk.magenta('Kickass'), value: "kickass"});
-      }
-      if(tpb_url){
-        sites.push({'key': "tpb", name: chalk.magenta('The Pirate Bay'), value: "tpb"});
-      }
-      if(rarbg_url){
-        sites.push({'key': "rarbg", name: chalk.magenta('Rarbg'), value: "rarbg"});
-      }
-      if(seedpeer_url){
-        sites.push({'key': "seedpeer", name: chalk.magenta('Seedpeer'), value: "seedpeer"});
-      }
-      if(btdigg_url){
-        sites.push({'key': "btdigg", name : chalk.magenta('BTDigg'), value: "btdigg"});
-      }
-      if(strike_url){
-        sites.push({'key': "strike", name: chalk.magenta('GetStrike'), value: "strike"});
-      }
-      if(leetx_url){
-        sites.push({'key': "leetx", name: chalk.magenta('1337x'), value: "leetx"});
-      }
-      if(limetorrents_url){
-        sites.push({'key': "limetorrents", name: chalk.magenta('LimeTorrents'), value: "limetorrents"});
-      }
-      if(extratorrent_url){
-        sites.push({'key': "extratorrent", name: chalk.magenta('ExtraTorrent'), value: "extratorrent"});
-      }
-      if(nyaa_url){
-        sites.push({'key': "nyaa", name: chalk.magenta('Nyaa'), value: "nyaa"});
-      }
-      if(tokyotosho_url){
-        sites.push({'key': "tokyotosho", name: chalk.magenta('Tokyotosho'), value: "tokyotosho"});
-      }
-      if(cpasbien_url){
-        sites.push({'key': "cpasbien", name: chalk.magenta('Cpasbien'), value: "cpasbien"});
-      }
-      if(eztv_url){
-        sites.push({'key': "eztv", name: chalk.magenta('Eztv'), value: "eztv"});
-      }
+      
       if(history === "true"){
-        sites.push({'key': "print history", name: chalk.blue('Print history'), value: "print history"});
+        sites.push({
+          'key': "print history",
+          name: chalk.blue('Print history'),
+          value: "print history"
+        });
       }
 
       sites.push({'key': "exit", name: chalk.red('Exit app'), value: "exit"});
@@ -170,43 +146,44 @@
         }
         function passoffSearch( search ) {
           console.log(chalk.green("Searching for ") + chalk.blue(search));
-          if(site === "kickass"){
-            kickassSearch(search);
-          } else if(site === "rarbg"){
-            rarbgSearch(search);
-          } else if(site === "seedpeer"){
-            seedpeerSearch(search);
-          } else if(site === "strike"){
-            strikeSearch(search);
-          } else if(site === "btdigg"){
-            btdiggSearch(search);
-          } else if(site === "leetx"){
-            leetxSearch(search);
-          } else if(site === "limetorrents"){
-            limetorrentSearch(search);
-          } else if(site === "yts"){
-            ytsSearch(search);
-          } else if(site === "tpb"){
-            tpbSearch(search);
-          } else if(site === "extratorrent"){
-            extratorrentSearch(search);
-          } else if (site === "nyaa"){
-            nyaaSearch(search);
-          } else if(site === "tokyotosho"){
-            tokyotoshoSearch(search);
-          } else if(site === "cpasbien"){
-            cpasbienSearch(search);
-          } else if(site === "eztv"){
-            eztvSearch(search);
-          }
+          console.log(site);
+          Search(site, search);
+          // if(site === "kickass"){
+          //   kickassSearch(search);
+          // } else if(site === "rarbg"){
+          //   rarbgSearch(search);
+          // } else if(site === "seedpeer"){
+          //   seedpeerSearch(search);
+          // } else if(site === "strike"){
+          //   strikeSearch(search);
+          // } else if(site === "btdigg"){
+          //   btdiggSearch(search);
+          // } else if(site === "leetx"){
+          //   leetxSearch(search);
+          // } else if(site === "limetorrents"){
+          //   limetorrentSearch(search);
+          // } else if(site === "yts"){
+          //   ytsSearch(search);
+          // } else if(site === "tpb"){
+          //   tpbSearch(search);
+          // } else if(site === "extratorrent"){
+          //   extratorrentSearch(search);
+          // } else if (site === "nyaa"){
+          //   nyaaSearch(search);
+          // } else if(site === "tokyotosho"){
+          //   tokyotoshoSearch(search);
+          // } else if(site === "cpasbien"){
+          //   cpasbienSearch( search);
+          // } else if(site === "eztv"){
+          //   eztvSearch(search);
+          // }
         }
 
       }
 
     }
-
-    function btdiggSearch(query){
-      btdigg.search(query, btdigg_url).then(
+    function Search(site, query){
+      scrapers[site].search(query, config_object['torrent_sources'][site].url).then(
         function (data) {
             onResolve(data);
         }, function (err) {
@@ -214,129 +191,138 @@
         });
     }
 
-    function leetxSearch(query){
-      leetx.search(query, leetx_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function btdiggSearch(query){
+    //   btdigg.search(query, btdigg_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
+
+    // function leetxSearch(query){
+    //   leetx.search(query, leetx_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
 
 
-    function seedpeerSearch(query){
-      seedpeer.search(query, seedpeer_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function seedpeerSearch(query){
+    //   seedpeer.search(query, seedpeer_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
-    function rarbgSearch(query){
-      rarbg.search(query, cat, page, rarbg_api_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function rarbgSearch(query){
+    //   rarbg.search(query, cat, page, rarbg_api_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
-    function extratorrentSearch(query){
-      console.log(chalk.red("(*note Extratorrent does not sort by seeds)"));
-      extratorrent.search(query, cat, page, extratorrent_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function extratorrentSearch(query){
+    //   console.log(chalk.red("(*note Extratorrent does not sort by seeds)"));
+    //   extratorrent.search(query, cat, page, extratorrent_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
-    function strikeSearch(query){
-      strike.search(query, cat, page, strike_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
-
-
-    function ytsSearch(query){
-      yts.search(query, cat, page, yts_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function strikeSearch(query){
+    //   strike.search(query, cat, page, strike_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
 
-    function tpbSearch(query){
-      //console.log(chalk.red("Use caution using thepiratebay, Fake torrents are common, Look for trusted uploader skull."));
-      tpb.search(query, cat, page, tpb_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
-
-    function limetorrentSearch(query){
-      limetorrents.search(query, cat, page, limetorrents_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
-
-    function kickassSearch(query) {
-      kickass.search(query, cat, page, kickass_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function ytsSearch(query){
+    //   yts.search(query, cat, page, yts_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
 
-    function nyaaSearch(query){
-      nyaa.search(query, cat, page, nyaa_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function tpbSearch(query){
+    //   //console.log(chalk.red("Use caution using thepiratebay, Fake torrents are common, Look for trusted uploader skull."));
+    //   tpb.search(query, cat, page, tpb_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
-    function tokyotoshoSearch(query){
-      tokyotosho.search(query, cat, page, tokyotosho_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function limetorrentSearch(query){
+    //   limetorrents.search(query, cat, page, limetorrents_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
-    function cpasbienSearch(query){
-      cpasbien.search(query, cpasbien_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+    // function kickassSearch(query) {
+    //   kickass.search(query, cat, page, kickass_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
-    function eztvSearch(query){
-      eztv.search(query, eztv_url).then(
-        function (data) {
-            onResolve(data);
-        }, function (err) {
-            onReject(err);
-        });
-    }
+
+    // function nyaaSearch(query){
+    //   nyaa.search(query, cat, page, nyaa_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
+
+    // function tokyotoshoSearch(query){
+    //   tokyotosho.search(query, cat, page, tokyotosho_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
+
+    // function cpasbienSearch(query){
+    //   cpasbien.search(query, cpasbien_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
+
+    // function eztvSearch(query){
+    //   eztv.search(query, eztv_url).then(
+    //     function (data) {
+    //         onResolve(data);
+    //     }, function (err) {
+    //         onReject(err);
+    //     });
+    // }
 
     function onResolve(data) {
         for (var idx in data) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -48,6 +48,7 @@
     var get_conf_object = new Configstore("torrentflix_config", {});
     var get_hist_object = new Configstore("torrentflix_history", {});
 
+    // link short_name and scraper object
     var scrapers = {
       'cpasbien': cpasbien,
       'kickass': kickass,
@@ -67,6 +68,7 @@
 
     exports.AppInitialize = start = function(optns) {
       options = optns;
+      // get all options from the config file
       config_object = get_conf_object.all;
 
       //setting up vars from config
@@ -129,7 +131,7 @@
       } else {
         if (options.search) {
             passoffSearch(options.search);
-        } else if(options.open && options.open != true) {
+        } else if (options.open && options.open !== true) {
             passoffSearch(options.open);
         } else {
           inquirer.prompt([

--- a/lib/nyaa.js
+++ b/lib/nyaa.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, cat, page, nyaa_url) {
+  search: function(query, nyaa_url, cat, page) {
     //http://www.nyaa.se/?page=search&term=Absolute+Duo&sort=2
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');

--- a/lib/rarbg.js
+++ b/lib/rarbg.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, cat, page, rarbg_api_url) {
+  search: function(query, rarbg_api_url, cat, page) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');

--- a/lib/seedpeer.js
+++ b/lib/seedpeer.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, seedpeer_url) {
+  search: function(query, seedpeer_url, cat, page) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('-');

--- a/lib/strike.js
+++ b/lib/strike.js
@@ -3,7 +3,7 @@ var request = require("request");
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, cat, page, strike_url) {
+  search: function(query, strike_url, cat, page) {
     var count = 1;
     var deferred = Q.defer();
     var data_content = {};

--- a/lib/thepiratebay.js
+++ b/lib/thepiratebay.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, cat, page, thepiratebay_url) {
+  search: function(query, thepiratebay_url, cat, page) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('%20');

--- a/lib/tokyotosho.js
+++ b/lib/tokyotosho.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, cat, page, tokyotosho_url) {
+  search: function(query, tokyotosho_url, cat, page) {
     //http://www.nyaa.se/?page=search&term=Absolute+Duo&sort=2
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');

--- a/lib/yts.js
+++ b/lib/yts.js
@@ -3,7 +3,7 @@ var request = require("request");
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, cat, page, yts_url) {
+  search: function(query, yts_url, cat, page) {
     var count = 1;
     var deferred = Q.defer();
     var data_content = {};


### PR DESCRIPTION
Refactoring on main.js, just one search function for all sources. Now if we want add source, we just need to develop the scraper and add some vars :  
- in cli.js (short name, name and url)
- in main.js (link short name to scraper object name)

It will be much easier to add a default search engine from the command line, next step if nobody do it.

'cat' and 'page' have been added to all scrapers, one day, maybe this will be useful ! 
