### PR TITLE
add engine search option and limit option from command line #24

### DIFF
--- a/lib/1337x.js
+++ b/lib/1337x.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, leetx_url) {
+  search: function(query, leetx_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');
@@ -51,9 +51,8 @@ module.exports = {
                 torrent_content.push(data_content);
 
                 deferred.resolve(torrent_content);
-                count++;
-
-
+                // like break
+                if (++count > limit) { return false; }
               }
             });
 

--- a/lib/btdigg.js
+++ b/lib/btdigg.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, btdigg_url, cat, page) {
+  search: function(query, btdigg_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('%20');
@@ -51,7 +51,8 @@ module.exports = {
 
               deferred.resolve(torrent_content);
 
-              count++;
+              // like break
+              if (++count > limit) { return false; }
             }
 
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -96,11 +96,12 @@
         .option('--config', 'Edit torrentflix config EX: torrentflix --config="nano"')
         .option('-s, --search [title]', 'item to search for EX: -s title')
         .option('-o, --open [title]', 'open torrent with default app or xdg-open')
+        .option('-e, --engine [name]', 'which website use for the search, EX: -e tpb')
+        .option('-l, --limit [int]', 'limit the number of results, EX: -l 10')
         //.option('--history', 'View torrentflix history EX: torrentflix --history')
         .option('--clear', 'Clear torrentflix history EX torrentflix --clear')
         //.option('--location', 'Change where torrentflix\' config & history is located EX torrentflix --location"/home/gshock/.config"')
         .parse(process.argv);
-
     //if config command has been called
     if (program.config) {
         if (program.args[0]) {
@@ -148,12 +149,12 @@
         });
     }
 
-    program.parse(process.argv);
-
     function AppInitialize(prog) {
         var appOpts = {
             open: prog.open,
-            search: prog.search
+            search: prog.search,
+            engine: prog.engine,
+            limit: prog.limit
         };
         var conf = new Configstore("torrentflix_config", {});
         var hist = new Configstore("torrentflix_history", {});
@@ -164,7 +165,6 @@
             console.log(chalk.green("A new config file has been created you can find it at: "));
             console.log(chalk.green(conf.path));
 
-            main.AppInitialize(appOpts);
         } else {
 
             // config file exist, get values
@@ -184,10 +184,8 @@
             if (need_save) { 
                 conf.set(conf_file);
             }
-
-
-          main.AppInitialize(appOpts);
         }
+        main.AppInitialize(appOpts);
     }
 
     function clearHistory() {

--- a/lib/cpasbien.js
+++ b/lib/cpasbien.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, cpasbien_url, cat, page) {
+  search: function(query, cpasbien_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('-');
@@ -45,7 +45,8 @@ module.exports = {
             torrent_content.push(data_content);
 
             deferred.resolve(torrent_content);
-            count++;
+            // like break
+            if (++count > limit) { return false; }
           });
 
         } else {

--- a/lib/extratorrent.js
+++ b/lib/extratorrent.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, extratorrent_url, cat, page) {
+  search: function(query, extratorrent_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');
@@ -53,7 +53,8 @@ module.exports = {
 
               deferred.resolve(torrent_content);
 
-              count++;
+              // like break
+              if (++count > limit) { return false; }
 
             }
 

--- a/lib/eztv.js
+++ b/lib/eztv.js
@@ -6,7 +6,7 @@ var util = require('util');
 var fs = require('fs');
 
 module.exports = {
-  search: function(query, eztv_url, cat, page) {
+  search: function(query, eztv_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('-');
@@ -51,7 +51,8 @@ module.exports = {
               torrent_content.push(data_content);
   
               deferred.resolve(torrent_content);
-              count++;
+              // like break
+              if (++count > limit) { return false; }
             });
   
           } else {

--- a/lib/kickass.js
+++ b/lib/kickass.js
@@ -3,7 +3,7 @@ var request = require("request");
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, kickass_url, cat, page) {
+  search: function(query, kickass_url, cat, page, limit) {
     var count = 1;
     var deferred = Q.defer();
     var data_content = {};
@@ -50,7 +50,8 @@ module.exports = {
             torrent_content.push(data_content);
 
             deferred.resolve(torrent_content);
-            count++;
+            // like break
+            if (++count > limit) { return false; }
           }
         } else {
           deferred.reject("No torrents found");

--- a/lib/limetorrents.js
+++ b/lib/limetorrents.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, limetorrents_url, cat, page) {
+  search: function(query, limetorrents_url, cat, page, limit) {
 
     if(!cat){
       cat = "all";
@@ -57,7 +57,8 @@ module.exports = {
               torrent_content.push(data_content);
 
               deferred.resolve(torrent_content);
-              count++;
+              // like break
+              if (++count > limit) { return false; }
             }
 
           });

--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,7 @@
     var peerflix_player, peerflix_player_arg, peerflix_port, peerflix_command, 
         use_subtitle, subtitle_language, history, history_location,
         conf_date_added, history_object, config_location, cat, page, 
-        peerflix_path;
+        peerflix_path, limit;
 
     //load in language settings
     var lang = language.getEn();
@@ -67,7 +67,9 @@
     };
 
     exports.AppInitialize = start = function(optns) {
+      // get option pass in cli (-s, -o, ...)
       options = optns;
+
       // get all options from the config file
       config_object = get_conf_object.all;
 
@@ -83,24 +85,14 @@
       page = 1;
       peerflix_path = config_object.options.peerflix_path;
 
-      firstPrompt();
+      firstPrompt(options);
 
     };
 
 
 
-    function firstPrompt() {
+    function firstPrompt(options) {
       var sites = [];
-
-      for (var source in config_object.torrent_sources) {
-        // add torrent sources 
-        sites.push({
-            'key': source,
-            name: chalk.magenta(config_object.torrent_sources[source].name),
-            value: source
-          });
-      }
-      
       if (history === "true") {
         sites.push({
           'key': "print history",
@@ -108,19 +100,43 @@
           value: "print history"
         });
       }
+      if (options.limit && options.limit !== true) {
+        limit = options.limit;
+      }
+      if (options.engine === true) {
+        console.log(chalk.red("Pease specify a name of the search engine to " +
+          "select :"));
+        for (var s in config_object.torrent_sources) {
+          // show the source list
+          console.log(config_object.torrent_sources[s].name + " -> " + 
+            chalk.green(s));
+        }
+      }
+      else if (options.engine) {
+        torrentSite(options.engine, limit);
+      } else {
+        for (var source in config_object.torrent_sources) {
+        // add torrent sources 
+        sites.push({
+            'key': source,
+            name: chalk.magenta(config_object.torrent_sources[source].name),
+            value: source
+          });
+        }
+        sites.push({'key': "exit", name: chalk.red('Exit app'), value: "exit"});
 
-      sites.push({'key': "exit", name: chalk.red('Exit app'), value: "exit"});
-
-      inquirer.prompt([{
-          type: "list",
-          name: "site",
-          message: chalk.green("What torrent site do you want to search?"),
-          choices: sites
-        }], function( answer ) {
-          torrentSite(answer.site);
-        }); 
+        inquirer.prompt([{
+            type: "list",
+            name: "site",
+            message: chalk.green("What torrent site do you want to search?"),
+            choices: sites
+          }], function(answer) {
+            torrentSite(answer.site, limit);
+          }); 
+      }
     }
-    function torrentSite(site) {
+      
+    function torrentSite(site, limit) {
 
       if (site == "print history") {
         printHistory();
@@ -130,10 +146,10 @@
       } else {
         // if -s and not empty
         if (options.search && options.search !== true) {
-            Search(options.search, site);
+            Search(options.search, site, cat, page, limit);
         // if -o and not empty
         } else if (options.open && options.open !== true) {
-            Search(options.open, site);
+            Search(options.open, site, cat, page, limit);
         } else {
           inquirer.prompt([
             {
@@ -143,17 +159,20 @@
             }
           ], 
           function(answer) {
-            Search(answer.search, site, cat, page);          
+            Search(answer.search, site, cat, page, limit);          
           });
         }
       }
     }
 
-    function Search(query, site, cat, page) {
+    function Search(query, site, cat, page, limit) {
       // general search function for all sources
-      console.log(chalk.green("Searching for ") + chalk.blue(query));
+      console.log(chalk.green("Searching for ") + chalk.blue(query) + 
+        chalk.green(" on ") + chalk.blue(
+          config_object.torrent_sources[site].name) + chalk.green("..."));
+
       search_url = config_object.torrent_sources[site].url;
-      scrapers[site].search(query, search_url, cat, page).then(
+      scrapers[site].search(query, search_url, cat, page, limit).then(
         function (data) {
             onResolve(data);
         }, function (err) {

--- a/lib/nyaa.js
+++ b/lib/nyaa.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, nyaa_url, cat, page) {
+  search: function(query, nyaa_url, cat, page, limit) {
     //http://www.nyaa.se/?page=search&term=Absolute+Duo&sort=2
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');
@@ -49,7 +49,8 @@ module.exports = {
             torrent_content.push(data_content);
 
             deferred.resolve(torrent_content);
-            count++;
+            // like break
+            if (++count > limit) { return false; }
 
           });
         } else {

--- a/lib/rarbg.js
+++ b/lib/rarbg.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, rarbg_api_url, cat, page) {
+  search: function(query, rarbg_api_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');
@@ -50,7 +50,8 @@ module.exports = {
                       torrent_content.push(data_content);
 
                       deferred.resolve(torrent_content);
-                      count++;
+                      // like break
+                      if (++count > limit) { return false; }
 
                     }
                 } else {

--- a/lib/seedpeer.js
+++ b/lib/seedpeer.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, seedpeer_url, cat, page) {
+  search: function(query, seedpeer_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('-');
@@ -54,7 +54,8 @@ module.exports = {
                   torrent_content.push(data_content);
 
                   deferred.resolve(torrent_content);
-                  count++;
+                  // like break
+                  if (++count > limit) { return false; }
 
                 }
               });

--- a/lib/strike.js
+++ b/lib/strike.js
@@ -3,7 +3,7 @@ var request = require("request");
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, strike_url, cat, page) {
+  search: function(query, strike_url, cat, page, limit) {
     var count = 1;
     var deferred = Q.defer();
     var data_content = {};
@@ -41,7 +41,8 @@ module.exports = {
             torrent_content.push(data_content);
 
             deferred.resolve(torrent_content);
-            count++;
+            // like break
+            if (++count > limit) { return false; }
           }
       } else {
         deferred.reject("No torrents found.");

--- a/lib/thepiratebay.js
+++ b/lib/thepiratebay.js
@@ -3,7 +3,7 @@ var request = require("request");
 var cheerio = require('cheerio');
 
 module.exports = {
-  search: function(query, thepiratebay_url, cat, page) {
+  search: function(query, thepiratebay_url, cat, page, limit) {
 
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('%20');
@@ -82,7 +82,8 @@ module.exports = {
 
             torrent_content.push(data_content);
             deferred.resolve(torrent_content);
-            count++;
+            // like break
+            if (++count > limit) { return false; }
 
           }
 

--- a/lib/tokyotosho.js
+++ b/lib/tokyotosho.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, tokyotosho_url, cat, page) {
+  search: function(query, tokyotosho_url, cat, page, limit) {
     //http://www.nyaa.se/?page=search&term=Absolute+Duo&sort=2
     var torrent_search = query;
     var search_query = torrent_search.split(' ').join('+');
@@ -59,7 +59,8 @@ module.exports = {
               torrent_content.push(data_content);
 
               deferred.resolve(torrent_content);
-              count++;
+              // like break
+              if (++count > limit) { return false; }
 
             }
 

--- a/lib/yts.js
+++ b/lib/yts.js
@@ -3,7 +3,7 @@ var request = require("request");
 var moment = require('moment');
 
 module.exports = {
-  search: function(query, yts_url, cat, page) {
+  search: function(query, yts_url, cat, page, limit) {
     var count = 1;
     var deferred = Q.defer();
     var data_content = {};
@@ -51,7 +51,8 @@ module.exports = {
               torrent_content.push(data_content);
 
               deferred.resolve(torrent_content);
-              count++;
+              // like break
+              if (++count > limit) { return false; }
 
 
             }


### PR DESCRIPTION
Oh yeah ! this PR close the issue #24 and/or #37 :smiley: 
- Add of engine search option (-e short_name). If no name is provided, a list of sources names is shown.
- Add possibility to limit the number of result (-l 10), useful with eztv 

Example : torrentflix -s walking -e eztv -l 5

The idea of this PR was so good.
