### PR TITLE
bugfix torrent parse could crash cause of bad http certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 history.json
+.idea

--- a/hw.js
+++ b/hw.js
@@ -1,0 +1,1 @@
+console.log("ciaone!");

--- a/hw.js
+++ b/hw.js
@@ -1,1 +1,0 @@
-console.log("ciaone!");

--- a/lib/1337x.js
+++ b/lib/1337x.js
@@ -22,8 +22,8 @@ module.exports = {
 
         $ = cheerio.load(body);
 
-        if($('.tab-detail ul li').length > 0){
-          $('.tab-detail ul li').each(function(index, torrents){
+        if($('.table-list tbody').length > 0){
+          $('.table-list tbody').each(function(index, torrents) {
             var d = $(this);
             var div = d.children('div');
             links = $(torrents).find('a');

--- a/lib/extratorrent.js
+++ b/lib/extratorrent.js
@@ -21,7 +21,8 @@ module.exports = {
 
         $ = cheerio.load(body);
 
-        if($('.tl').find('tr').length > "3"){
+        if($('.tl')
+                .find('tr').length > "3"){
           $('.tl tr').each(function(index, torrents){
 
             if($(torrents).find('td a img').attr('alt') !== 'Sort'){

--- a/lib/torrent_parse.js
+++ b/lib/torrent_parse.js
@@ -1,6 +1,6 @@
 var Q = require('q');
 var readTorrent = require('read-torrent');
-
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; //read torrent may fail if no  valid certificate is found
 
 module.exports = {
   parseTorrent: function(torrent) {

--- a/lib/torrent_parse.js
+++ b/lib/torrent_parse.js
@@ -17,7 +17,7 @@ module.exports = {
     } else {
       readTorrent(torrent,function(err, torrent) {
 
-        if(typeof torrent.files !== undefined){
+        if(torrent &&  typeof torrent.files !== undefined){
           torrent.files.forEach(function(torrent_files) {
 
             torrent_content.push(torrent_files.name);

--- a/lib/torrent_search.js
+++ b/lib/torrent_search.js
@@ -26,12 +26,15 @@ module.exports = {
 
         var magnet_link, torrent_link;
         $(links).each(function(i, link){
-          if($(link).attr('href')){
-            if($(link).attr('href').indexOf("magnet:?xt=urn:btih:") > -1) {
+
+          var torrentLink = $(link).attr('href');
+
+          if(torrentLink){
+            if(torrentLink.indexOf("magnet:?xt=urn:btih:") > -1) {
               magnet_link = $(link).attr('href');
               deferred.resolve(magnet_link);
             }
-            else if($(link).attr('href').indexOf(".torrent") > -1) {
+            else if(torrentLink.match(/\.torrent$/)) {
               torrent_link = $(link).attr('href');
               deferred.resolve(url.resolve(torrent_site, torrent_link));
             }


### PR DESCRIPTION
torrent_parse.js uses 'read_torrent' library that, in turn, uses 'request'. This library may fail if no valid http certificate is found while downloading a torrent file causing torrentflix to crash.
This fix, almost a hack, solves the problem.