### PR TITLE
Fixed yts torrent links

### DIFF
--- a/lib/yts.js
+++ b/lib/yts.js
@@ -34,7 +34,7 @@ module.exports = {
               var leechs = data.data.movies[torrent].torrents[torrents].peers;
               //var torrent_link = data.data.movies[torrent].torrents[torrents].url;
               var hash = data.data.movies[torrent].torrents[torrents].hash;
-              var torrent_link = "http://torcache.net/torrent/" + hash + ".torrent";
+              var torrent_link = yts_url + "/torrent/download/" + hash;
               var size = data.data.movies[torrent].torrents[torrents].size;
               var date_added = moment(Date.parse(data.data.movies[torrent].torrents[torrents].date_uploaded.split(' ')[0])).fromNow();
 


### PR DESCRIPTION
Usually `yts.js` would provide torrent links from torcache which is dead apparently. This PR fixed it.