### PR TITLE
Update yts base url

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -31,7 +31,7 @@
             },
             "yts": {
                 name: 'YTS',
-                url: "https://yts.ag"
+                url: "https://yts.mx"
             },
             "tpb": {
                 name: 'The Pirate Bay',


### PR DESCRIPTION
Because yts.ag is down
this PR update the yts base url to a working mirror `htps://yts.mx`